### PR TITLE
Fixing one of the template references

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -23,7 +23,7 @@ openshift_cluster_content:
 - object: ci-cd-builds
   content:
   - name: jenkins-s2i
-    template: "https://github.com/rht-labs/labs-ci-cd/blob/v0.3.0/openshift-templates/jenkins-s2i-build/template.json"
+    template: "https://raw.githubusercontent.com/rht-labs/labs-ci-cd/v0.3.0/openshift-templates/jenkins-s2i-build/template.json"
     params: "{{ inventory_dir }}/params/build/jenkins_s2i"
     namespace: labs-ci-cd
     tags:


### PR DESCRIPTION
One of the templates referenced in the inventory had the normal github url, not the raw file. The ansible script failed as a result. This fixes it.

/cc @InfoSec812 